### PR TITLE
Can provide an alternative git executable thru GIT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ You can get your first achievement by running
 ```
 git achievements --help
 ```
+
+To keep using [*hub*](https://github.com/github/hub) command line tool,
+use the following shell alias in your `~/.bash_profile`:
+```
+alias git="GIT=/path/to/hub git-achievements"
+```

--- a/git-achievements
+++ b/git-achievements
@@ -485,7 +485,7 @@ ACTIONLOGFILE="$HOME/.git-achievements-action.log"
 ACHIEVEMENTSLOGFILE="$HOME/.git-achievements.log"
 
 if [ ! "$1" = "achievements" ] ; then
-    git "$@"
+    "${GIT:-git}" "$@"
     r=$?
     if [ ! ${r} -eq 0 ] ; then
         exit $r


### PR DESCRIPTION
This patch provides a simple way to support all kind of existing git wrapper utilities like GitHub `hub`.