### PR TITLE
Fix changing directory to git-achieements in MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,18 @@ You can get your first achievement by running
 ```
 git achievements --help
 ```
+
+### macOS
+
+You need to install GNU Coreutils and make the GNU `readlink` command available as `greadlink`. An easy way to do that is to use Homebrew to install coreutils. 
+
+```
+brew update && brew install coreutils
+```
+
+Run the followng command or add it to your `~/.bash_profile~
+
+```
+export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+```
+

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ There are over 40 achievements, most with different levels to be achieved. After
 
 A log of all of your achievements is kept locally, but you can also publish it to GitHub pages so you can share your achievements (and there is an RSS feed so people can track your achievements).
 
-For example the project maintainer's achievements page is at http://icefox.github.io/git-achievements/.
+For example the project maintainer's achievements page is at http://hanxue.github.io/git-achievements/.
 
-If you are viewing a forked version of git-achievements you want to replace icefox with the GitHub user account you want to see like so:
+If you are viewing a forked version of git-achievements you want to replace hanxue with the GitHub user account you want to see like so:
 
 http://**username**.github.com/git-achievements
 

--- a/git-achievements
+++ b/git-achievements
@@ -371,8 +371,14 @@ function publish_achievements
 {
     git_achievements="$(which git-achievements)"
     git_achievements_dir="$(dirname "${git_achievements}")"
+    value=""
+    if ! type "greadlink" > /dev/null; then
+        value="$(dirname $(readlink ${git_achievements}))"
+    else
+        value="$(dirname $(greadlink ${git_achievements}))"
+    fi
     if [ -L "${git_achievements}" ]; then
-      case "$(dirname $(readlink ${git_achievements}))" in
+      case ${value} in
         /*)
           git_achievements_dir="$(dirname $(readlink ${git_achievements}))"
           ;;

--- a/git-achievements
+++ b/git-achievements
@@ -408,7 +408,7 @@ echo "
     levels=`clean_logged_achievements | awk '{ if (NR % 2 != 0) print $0 }' | grep Level | sed -e 's/.* //g' -e 's/)//g' | awk '{ t=t+$0 } END { print t }'`
     onelevels=`clean_logged_achievements | awk '{ if (NR % 2 != 0) print $0 }' | wc -l`
     let points="${levels}"+"${onelevels}"
-    echo "Unlocked ${unlockedCount}/$total <a href=\"http://github.com/icefox/git-achievements\">Git Achievements</a> for $points points<br>" >> index.html
+    echo "Unlocked ${unlockedCount}/$total <a href=\"http://github.com/hanxue/git-achievements\">Git Achievements</a> for $points points<br>" >> index.html
 
     unlocked=`cat "${ACHIEVEMENTSLOGFILE}" | grep Unlocked | wc -l`
 

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked       10/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 34 points<br>
+Unlocked       10/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 39 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
 <li><div class="title">Apprentice Banker (Level 1)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
@@ -24,31 +24,35 @@ Unlocked       10/      51 <a href="http://github.com/hanxue/git-achievements">G
 <li><div class="title">Apprentice Socialite (Level 2)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Apprentice Stone Mason (Level 1)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
 <li><div class="title">Garage Inventor</div>  <div class="info">Used a custom alias for a Git command</div></li>
+<li><div class="title">Historian (Level 4)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Master Carpenter (Level        4)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
 <li><div class="title">Student</div>  <div class="info">Accessed the documentation for a command with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-.html">git-</a>[command] --help</div></li>
 </ul>
 Git commands sorted by usage:
 <pre style="text-align: left">
-  14 achievements
-  12 log
-   7 checkout
-   6 status
+  18 achievements
+  15 log
+   9 checkout
+   7 status
    4 reset
    4 push
    3 rebase
    3 merge
+   3 diff
+   3 !
    2 whatchanged
+   2 rm
    2 init
+   2 help
+   2 config
    2 blame
    2 add
    1 stash
    1 remote
    1 pull
-   1 help
-   1 diff
-   1 config
    1 commit
-   1 !
+   1 clone
+   1 branch
 </pre>
 <script type="text/javascript">
 function showLocked() {

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked       13/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 44 points<br>
+Unlocked       14/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 46 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
 <li><div class="title">Apprentice Banker (Level 1)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
@@ -20,6 +20,7 @@ Unlocked       13/      51 <a href="http://github.com/hanxue/git-achievements">G
 <li><div class="title">Apprentice Historian (Level 2)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Apprentice Historian (Level 3)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Apprentice Investigator (Level 1)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-blame.html">git-blame</a> to annotate a file with information about how each line changed.</div></li>
+<li><div class="title">Apprentice Merchant (Level 1)</div>  <div class="info">Added an external repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">git-remote</a> add.</div></li>
 <li><div class="title">Apprentice News Reader (Level 1)</div>  <div class="info">Show logs with difference each commit introduces with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-whatchanged.html">git-whatchanged</a></div></li>
 <li><div class="title">Apprentice Product Manager (Level 1)</div>  <div class="info">Stash the changes in a dirty working directory away with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-stash.html">git-stash</a>.</div></li>
 <li><div class="title">Apprentice Socialite (Level 1)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
@@ -33,29 +34,32 @@ Unlocked       13/      51 <a href="http://github.com/hanxue/git-achievements">G
 </ul>
 Git commands sorted by usage:
 <pre style="text-align: left">
-  20 achievements
-  16 log
+  22 achievements
+  19 log
   10 checkout
    9 status
    4 reset
+   4 remote
    4 push
+   3 stash
    3 rebase
    3 merge
    3 diff
+   3 config
    3 !
    2 whatchanged
-   2 stash
    2 rm
+   2 reflog
    2 mv
    2 init
    2 help
-   2 config
    2 commit
    2 blame
    2 add
-   1 remote
-   1 reflog
+   1 tag
+   1 submodule
    1 pull
+   1 instaweb
    1 clone
    1 branch
 </pre>
@@ -93,7 +97,6 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Let there be light</div><div class="info">Commit without a parent.</div></li>
 <li><div class="title">Librarian</div><div class="info">Looked for change that introduce or remove a string with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a> -S</div></li>
 <li><div class="title">Locksmith</div><div class="info">Add Signed-off-by line at the end of the commit log message using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> -s.</div></li>
-<li><div class="title">Merchant</div><div class="info">Added an external repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">git-remote</a> add.</div></li>
 <li><div class="title">Messenger</div><div class="info">Applied a patch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-am.html">git-am</a>.</div></li>
 <li><div class="title">Miller</div><div class="info">Add only part of a file to the stage X times with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a> -p.</div></li>
 <li><div class="title">Pedantic</div><div class="info">Use the flow extension to encourage an orderly and standardized branching model</div></li>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked       14/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 46 points<br>
+Unlocked       15/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 48 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
 <li><div class="title">Apprentice Banker (Level 1)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
@@ -26,6 +26,7 @@ Unlocked       14/      51 <a href="http://github.com/hanxue/git-achievements">G
 <li><div class="title">Apprentice Socialite (Level 1)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Apprentice Socialite (Level 2)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Apprentice Stone Mason (Level 1)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
+<li><div class="title">Apprentice Web Designer (Level 1)</div>  <div class="info">Instantly browse your working repository in gitweb with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-instaweb.html">git-instaweb</a></div></li>
 <li><div class="title">Garage Inventor</div>  <div class="info">Used a custom alias for a Git command</div></li>
 <li><div class="title">Historian (Level 4)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Master Carpenter (Level        4)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
@@ -34,32 +35,33 @@ Unlocked       14/      51 <a href="http://github.com/hanxue/git-achievements">G
 </ul>
 Git commands sorted by usage:
 <pre style="text-align: left">
+  22 log
   22 achievements
-  19 log
   10 checkout
    9 status
+   6 diff
+   5 remote
+   5 config
    4 reset
-   4 remote
    4 push
+   4 !
    3 stash
    3 rebase
    3 merge
-   3 diff
-   3 config
-   3 !
+   3 help
    2 whatchanged
+   2 submodule
    2 rm
    2 reflog
    2 mv
+   2 instaweb
    2 init
-   2 help
    2 commit
    2 blame
    2 add
    1 tag
-   1 submodule
+   1 show-branch
    1 pull
-   1 instaweb
    1 clone
    1 branch
 </pre>
@@ -109,6 +111,5 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Thug</div><div class="info">Forced pushed a branch with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a> -f</div></li>
 <li><div class="title">Traveler</div><div class="info">Streamed changes between another rcs with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-svn.html">git-svn</a> or <a href="http://www.kernel.org/pub/software/scm/git/docs/git-p4.html">git-p4</a>.</div></li>
 <li><div class="title">Tree Trimmer</div><div class="info">Rewrite branches with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-filter-branch.html">git-filter-branch</a></div></li>
-<li><div class="title">Web Designer</div><div class="info">Instantly browse your working repository in gitweb with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-instaweb.html">git-instaweb</a></div></li>
 </ul></div>
 </body></html>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked       15/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 48 points<br>
+Unlocked       15/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 51 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
 <li><div class="title">Apprentice Banker (Level 1)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
@@ -27,6 +27,7 @@ Unlocked       15/      51 <a href="http://github.com/hanxue/git-achievements">G
 <li><div class="title">Apprentice Socialite (Level 2)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Apprentice Stone Mason (Level 1)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
 <li><div class="title">Apprentice Web Designer (Level 1)</div>  <div class="info">Instantly browse your working repository in gitweb with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-instaweb.html">git-instaweb</a></div></li>
+<li><div class="title">Apprentice Web Designer (Level 2)</div>  <div class="info">Instantly browse your working repository in gitweb with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-instaweb.html">git-instaweb</a></div></li>
 <li><div class="title">Garage Inventor</div>  <div class="info">Used a custom alias for a Git command</div></li>
 <li><div class="title">Historian (Level 4)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Master Carpenter (Level        4)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
@@ -44,6 +45,7 @@ Git commands sorted by usage:
    5 config
    4 reset
    4 push
+   4 instaweb
    4 !
    3 stash
    3 rebase
@@ -54,7 +56,6 @@ Git commands sorted by usage:
    2 rm
    2 reflog
    2 mv
-   2 instaweb
    2 init
    2 commit
    2 blame

--- a/index.html
+++ b/index.html
@@ -3,233 +3,26 @@
 <html xmlns=http://www.w3.org/1999/xhtml>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-<title>Benjamin C Meyer's Git Achievements</title>
+<title>Lee Hanxue's Git Achievements</title>
 <link rel="alternate" type="application/rss+xml" title="rss feed" href="index.rss"/>
 <link rel="stylesheet" type="text/css" href="style.css"/>
 </head>
 <body>
 
-<h2>Benjamin C Meyer's Git Achievements <img src='http://www.gravatar.com/avatar/dc848256f8954abd612cbe7e81859f91'/></h2>
-Unlocked       38/      51 <a href="http://github.com/icefox/git-achievements">Git Achievements</a> for 709 points<br>
+<h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
+Unlocked        2/      51 <a href="http://github.com/icefox/git-achievements">Git Achievements</a> for 3 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
-<li><div class="title">Apprentice Architect (Level 2)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
-<li><div class="title">Apprentice Architect (Level 3)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
-<li><div class="title">Apprentice Archivist (Level 1)</div>  <div class="info">Prepare each commit with its patch in one file per commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-format-patch.html">git-format-patch</a></div></li>
-<li><div class="title">Apprentice Archivist (Level 2)</div>  <div class="info">Prepare each commit with its patch in one file per commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-format-patch.html">git-format-patch</a></div></li>
-<li><div class="title">Apprentice Archivist (Level 3)</div>  <div class="info">Prepare each commit with its patch in one file per commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-format-patch.html">git-format-patch</a></div></li>
-<li><div class="title">Apprentice Author (Level 1)</div>  <div class="info">Made 2^Level commits using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a>.</div></li>
-<li><div class="title">Apprentice Author (Level 2)</div>  <div class="info">Made 2^Level commits using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a>.</div></li>
-<li><div class="title">Apprentice Blacksmith (Level 1)</div>  <div class="info">Created a branch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">git-checkout</a> -b.</div></li>
-<li><div class="title">Apprentice Blacksmith (Level 2)</div>  <div class="info">Created a branch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">git-checkout</a> -b.</div></li>
-<li><div class="title">Apprentice Blacksmith (Level 3)</div>  <div class="info">Created a branch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">git-checkout</a> -b.</div></li>
-<li><div class="title">Apprentice Butcher (Level 1)</div>  <div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
-<li><div class="title">Apprentice Butcher (Level 2)</div>  <div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
-<li><div class="title">Apprentice Butcher (Level 3)</div>  <div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
-<li><div class="title">Apprentice Carpenter (Level 1)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
-<li><div class="title">Apprentice Carpenter (Level 2)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
-<li><div class="title">Apprentice Chimney Sweeper (Level 1)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-gc.html">git-gc</a> to run a number of housekeeping tasks on the current repository.</div></li>
-<li><div class="title">Apprentice Chimney Sweeper (Level 2)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-gc.html">git-gc</a> to run a number of housekeeping tasks on the current repository.</div></li>
-<li><div class="title">Apprentice Cleaning lady (Level 1)</div>  <div class="info">Remove untracked files from the working tree with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-clean.html">git-clean</a></div></li>
-<li><div class="title">Apprentice Cleaning lady (Level 2)</div>  <div class="info">Remove untracked files from the working tree with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-clean.html">git-clean</a></div></li>
-<li><div class="title">Apprentice Collector (Level 1)</div>  <div class="info">Fetches named heads or tags from another repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-fetch.html">git-fetch</a></div></li>
-<li><div class="title">Apprentice Collector (Level 2)</div>  <div class="info">Fetches named heads or tags from another repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-fetch.html">git-fetch</a></div></li>
-<li><div class="title">Apprentice Collector (Level 3)</div>  <div class="info">Fetches named heads or tags from another repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-fetch.html">git-fetch</a></div></li>
-<li><div class="title">Apprentice Fisherman (Level 2)</div>  <div class="info">Look for specified patterns in the current repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-grep.html">git-grep</a>.</div></li>
-<li><div class="title">Apprentice Gardner (Level 1)</div>  <div class="info">Shows the commit ancestry graph with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show-branch.html">git-show-branch</a></div></li>
-<li><div class="title">Apprentice Gipsy (Level 1)</div>  <div class="info">Create, list, delete a tag signed with GPG using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-tag.html">git-tag</a></div></li>
-<li><div class="title">Apprentice Goldsmith (Level 1)</div>  <div class="info">Reviewed patches before committing with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">git-diff</a> --cached.</div></li>
-<li><div class="title">Apprentice Goldsmith (Level 2)</div>  <div class="info">Reviewed patches before committing with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">git-diff</a> --cached.</div></li>
-<li><div class="title">Apprentice Goldsmith (Level 3)</div>  <div class="info">Reviewed patches before committing with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">git-diff</a> --cached.</div></li>
-<li><div class="title">Apprentice Historian (Level 1)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
-<li><div class="title">Apprentice Historian (Level 2)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
-<li><div class="title">Apprentice Hunter (Level 2)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-bisect.html">git-bisect</a> to perform a binary search to find which change introduced a bug.</div></li>
-<li><div class="title">Apprentice Investigator (Level 1)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-blame.html">git-blame</a> to annotates a file with information about how each line changed.</div></li>
-<li><div class="title">Apprentice Investigator (Level 2)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-blame.html">git-blame</a> to annotates a file with information about how each line changed.</div></li>
-<li><div class="title">Apprentice Investigator (Level 3)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-blame.html">git-blame</a> to annotates a file with information about how each line changed.</div></li>
-<li><div class="title">Apprentice Locksmith (Level 1)</div>  <div class="info">Add Signed-off-by line at the end of the commit log message using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> -s.</div></li>
-<li><div class="title">Apprentice Locksmith (Level 2)</div>  <div class="info">Add Signed-off-by line at the end of the commit log message using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> -s.</div></li>
-<li><div class="title">Apprentice Locksmith (Level 3)</div>  <div class="info">Add Signed-off-by line at the end of the commit log message using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> -s.</div></li>
-<li><div class="title">Apprentice Merchant (Level 1)</div>  <div class="info">Added an external repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">git-remote</a> add.</div></li>
-<li><div class="title">Apprentice Merchant (Level 2)</div>  <div class="info">Added an external repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">git-remote</a> add.</div></li>
-<li><div class="title">Apprentice Merchant (Level 3)</div>  <div class="info">Added an external repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">git-remote</a> add.</div></li>
-<li><div class="title">Apprentice Miller (Level 1)</div>  <div class="info">Add only part of a file to the stage 281 times with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a> -p.</div></li>
-<li><div class="title">Apprentice Miller (Level 2)</div>  <div class="info">Add only part of a file to the stage 394 times with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a> -p.</div></li>
-<li><div class="title">Apprentice Miller (Level 3)</div>  <div class="info">Add only part of a file to the stage 595 times with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a> -p.</div></li>
-<li><div class="title">Apprentice Pilgrim (Level 1)</div>  <div class="info">Performed a rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> --onto.</div></li>
-<li><div class="title">Apprentice Pilgrim (Level 2)</div>  <div class="info">Performed a rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> --onto.</div></li>
-<li><div class="title">Apprentice Pilgrim (Level 3)</div>  <div class="info">Performed a rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> --onto.</div></li>
-<li><div class="title">Apprentice Plumber (Level 1)</div>  <div class="info">Use the internal plumbing commands of git.</div></li>
-<li><div class="title">Apprentice Plumber (Level 2)</div>  <div class="info">Use the internal plumbing commands of git.</div></li>
-<li><div class="title">Apprentice Presenter (Level 1)</div>  <div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Apprentice Presenter (Level 2)</div>  <div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Apprentice Presenter (Level 3)</div>  <div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Apprentice Product Manager (Level 3)</div>  <div class="info">Stash the changes in a dirty working directory away with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-stash.html">git-stash</a>.</div></li>
-<li><div class="title">Apprentice Seamstress (Level 1)</div>  <div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
-<li><div class="title">Apprentice Seamstress (Level 2)</div>  <div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
-<li><div class="title">Apprentice Seamstress (Level 3)</div>  <div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
-<li><div class="title">Apprentice Socialite (Level 2)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
-<li><div class="title">Apprentice Socialite (Level 3)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
-<li><div class="title">Apprentice Stone Mason (Level 1)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
-<li><div class="title">Apprentice Stone Mason (Level 3)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
-<li><div class="title">Apprentice Thug (Level 1)</div>  <div class="info">Forced pushed a branch with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a> -f</div></li>
-<li><div class="title">Apprentice Thug (Level 2)</div>  <div class="info">Forced pushed a branch with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a> -f</div></li>
-<li><div class="title">Apprentice Thug (Level 3)</div>  <div class="info">Forced pushed a branch with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a> -f</div></li>
-<li><div class="title">Architect (Level 4)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
-<li><div class="title">Architect (Level 5)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
-<li><div class="title">Archivist (Level 4)</div>  <div class="info">Prepare each commit with its patch in one file per commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-format-patch.html">git-format-patch</a></div></li>
-<li><div class="title">Author (Level 5)</div>  <div class="info">Made 2^Level commits using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a>.</div></li>
-<li><div class="title">Author (Level 6)</div>  <div class="info">Made 2^Level commits using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a>.</div></li>
-<li><div class="title">Banker (Level 4)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
-<li><div class="title">Baptised</div>  <div class="info">Set global user name using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-config.html">git-config</a>.</div></li>
-<li><div class="title">Blacksmith (Level 4)</div>  <div class="info">Created a branch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">git-checkout</a> -b.</div></li>
-<li><div class="title">Blacksmith (Level 5)</div>  <div class="info">Created a branch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">git-checkout</a> -b.</div></li>
-<li><div class="title">Butcher (Level 4)</div>  <div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
-<li><div class="title">Butcher (Level 5)</div>  <div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
-<li><div class="title">Butcher (Level 6)</div>  <div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
-<li><div class="title">Caretaker</div>  <div class="info">Added a .gitignore file to a repository.</div></li>
-<li><div class="title">Carpenter (Level 6)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
-<li><div class="title">Cherry Picker</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-cherry-pick.html">git-cherry-pick</a> to add a sha from another branch into the current branch.</div></li>
-<li><div class="title">Chimney Sweeper (Level 4)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-gc.html">git-gc</a> to run a number of housekeeping tasks on the current repository.</div></li>
-<li><div class="title">Collector (Level 4)</div>  <div class="info">Fetches named heads or tags from another repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-fetch.html">git-fetch</a></div></li>
-<li><div class="title">Collector (Level 5)</div>  <div class="info">Fetches named heads or tags from another repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-fetch.html">git-fetch</a></div></li>
-<li><div class="title">Collector (Level 6)</div>  <div class="info">Fetches named heads or tags from another repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-fetch.html">git-fetch</a></div></li>
-<li><div class="title">Goldsmith (Level 4)</div>  <div class="info">Reviewed patches before committing with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">git-diff</a> --cached.</div></li>
-<li><div class="title">Goldsmith (Level 5)</div>  <div class="info">Reviewed patches before committing with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">git-diff</a> --cached.</div></li>
-<li><div class="title">Goldsmith (Level 6)</div>  <div class="info">Reviewed patches before committing with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">git-diff</a> --cached.</div></li>
-<li><div class="title">Historian (Level 4)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
-<li><div class="title">Historian (Level 5)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
-<li><div class="title">Historian (Level 6)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
-<li><div class="title">Homeowner</div>  <div class="info">Set global email address using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-config.html">git-config</a>.</div></li>
-<li><div class="title">Hunter (Level 4)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-bisect.html">git-bisect</a> to perform a binary search to find which change introduced a bug.</div></li>
-<li><div class="title">Inventor (achievements)</div>  <div class="info">Used a command that isn't part of the built in Git tools</div></li>
-<li><div class="title">Inventor (hooks)</div>  <div class="info">Used a command that isn't part of the built in Git command</div></li>
-<li><div class="title">Inventor (timecard)</div>  <div class="info">Used a command that isn't part of the built in Git command</div></li>
-<li><div class="title">Investigator (Level 4)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-blame.html">git-blame</a> to annotates a file with information about how each line changed.</div></li>
-<li><div class="title">Investigator (Level 5)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-blame.html">git-blame</a> to annotates a file with information about how each line changed.</div></li>
-<li><div class="title">Let there be light</div>  <div class="info">Commit without a parent.</div></li>
-<li><div class="title">Librarian</div>  <div class="info">Looked for change that introduce or remove a string with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a> -S</div></li>
-<li><div class="title">Master Author (Level 7)</div>  <div class="info">Made 2^Level commits using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a>.</div></li>
-<li><div class="title">Master Author (Level 9)</div>  <div class="info">Made 2^Level commits using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a>.</div></li>
-<li><div class="title">Master Butcher (Level 7)</div>  <div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
-<li><div class="title">Master Carpenter (Level       14)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
-<li><div class="title">Master Carpenter (Level 10)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
-<li><div class="title">Master Carpenter (Level 14)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
-<li><div class="title">Master Carpenter (Level 18)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
-<li><div class="title">Master Carpenter (Level 9)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
-<li><div class="title">Master Collector (Level 7)</div>  <div class="info">Fetches named heads or tags from another repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-fetch.html">git-fetch</a></div></li>
-<li><div class="title">Master Goldsmith (Level 7)</div>  <div class="info">Reviewed patches before committing with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">git-diff</a> --cached.</div></li>
-<li><div class="title">Master Goldsmith (Level 8)</div>  <div class="info">Reviewed patches before committing with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">git-diff</a> --cached.</div></li>
-<li><div class="title">Master Goldsmith (Level 9)</div>  <div class="info">Reviewed patches before committing with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">git-diff</a> --cached.</div></li>
-<li><div class="title">Master Historian (Level 7)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
-<li><div class="title">Master Historian (Level 8)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
-<li><div class="title">Master Historian (Level 9)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
-<li><div class="title">Master Miller (Level 7)</div>  <div class="info">Add only part of a file to the stage 1704 times with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a> -p.</div></li>
-<li><div class="title">Master Presenter (Level 10)</div>  <div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Master Presenter (Level 7)</div>  <div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Master Presenter (Level 8)</div>  <div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Master Presenter (Level 9)</div>  <div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Master Seamstress (Level 7)</div>  <div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
-<li><div class="title">Master Seamstress (Level 8)</div>  <div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
-<li><div class="title">Master Socialite (Level 7)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
-<li><div class="title">Master Socialite (Level 8)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
-<li><div class="title">Master Stone Mason (Level 10)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
-<li><div class="title">Master Stone Mason (Level 7)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
-<li><div class="title">Master Stone Mason (Level 8)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
-<li><div class="title">Master Stone Mason (Level 9)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
-<li><div class="title">Merchant (Level 4)</div>  <div class="info">Added an external repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">git-remote</a> add.</div></li>
-<li><div class="title">Merchant (Level 5)</div>  <div class="info">Added an external repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">git-remote</a> add.</div></li>
-<li><div class="title">Messenger (Level 5)</div>  <div class="info">Applied a patch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-am.html">git-am</a>.</div></li>
-<li><div class="title">Miller (Level 4)</div>  <div class="info">Add only part of a file to the stage 1028 times with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a> -p.</div></li>
-<li><div class="title">Miller (Level 5)</div>  <div class="info">Add only part of a file to the stage 1057 times with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a> -p.</div></li>
-<li><div class="title">Miller (Level 6)</div>  <div class="info">Add only part of a file to the stage 1262 times with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a> -p.</div></li>
-<li><div class="title">Presenter (Level 4)</div>  <div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Presenter (Level 5)</div>  <div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Presenter (Level 6)</div>  <div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Product Manager (Level 4)</div>  <div class="info">Stash the changes in a dirty working directory away with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-stash.html">git-stash</a>.</div></li>
-<li><div class="title">Seamstress (Level 4)</div>  <div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
-<li><div class="title">Seamstress (Level 5)</div>  <div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
-<li><div class="title">Seamstress (Level 6)</div>  <div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
-<li><div class="title">Socialite (Level 5)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
-<li><div class="title">Stone Mason (Level 4)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
-<li><div class="title">Stone Mason (Level 6)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
 <li><div class="title">Student</div>  <div class="info">Accessed the documentation for a command with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-.html">git-</a>[command] --help</div></li>
-<li><div class="title">Weaver</div>  <div class="info">Investigate old branches by using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-reflog.html">git-reflog</a></div></li>
 </ul>
 Git commands sorted by usage:
 <pre style="text-align: left">
-2519 status
-1636 add
-1428 diff
-1010 show
- 829 commit
- 736 log
- 496 rebase
- 333 push
- 302 checkout
- 228 branch
- 217 cherry-pick
- 184 fetch
- 123 hooks
-  95 reset
-  94 remote
-  76 rev-list
-  56 blame
-  50 rm
-  45 clone
-  42 init
-  30 achievements
-  29 gc
-  27 config
-  22 stash
-  19 tag
-  19 format-patch
-  18 send-email
-  18 bisect
-  17 rev-parse
-  16 am
-  14 --version
-  13 symbolic-ref
-  13 pull
-  10 timecard
-  10 prune
-  10 clean
-   9 reflog
-   9 mv
-   9 ls-tree
-   9 filter-branch
-   7 revert
-   7 merge
-   7 diff-index
-   6 ls-files
-   5 hash-object
-   5 cat-file
-   5 archive
-   4 update-ref
-   4 grep
-   4 describe
-   3 update-server-info
-   3 cvsimport
-   3 --help
-   2 unpack-objects
-   2 svn
-   2 submodule
-   2 show-branch
-   2 read-tree
-   1 write-tree
-   1 update-index
-   1 stage
-   1 shortlog
-   1 repack
-   1 notes
-   1 merge-base
-   1 mailsplit
-   1 mailinfo
-   1 ll
-   1 help
-   1 count
-   1 bundle
-   1 apply
+  11 achievements
+   3 status
+   2 init
+   1 remote
+   1 config
+   1 add
 </pre>
 <script type="text/javascript">
 function showLocked() {
@@ -241,18 +34,54 @@ function showLocked() {
 <div id="locked">
 There are       51 Achievements. Some achievements can be leveled up depending on the number of times it is used (Used 2 times = level 1, 4 = level 2, 8 = level 3, 16 = level 4, 32 = level 5, etc)
 <ul>
+<li><div class="title">Archivist</div><div class="info">Prepare each commit with its patch in one file per commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-format-patch.html">git-format-patch</a></div></li>
+<li><div class="title">Author</div><div class="info">Made 2^Level commits using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a>.</div></li>
+<li><div class="title">Banker</div><div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
+<li><div class="title">Baptised</div><div class="info">Set global user name using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-config.html">git-config</a>.</div></li>
 <li><div class="title">Beach Lion</div><div class="info">Restricted login shell for GIT-only SSH access with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-shell.html">git-shell</a></div></li>
+<li><div class="title">Blacksmith</div><div class="info">Created a branch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">git-checkout</a> -b.</div></li>
+<li><div class="title">Butcher</div><div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
+<li><div class="title">Caretaker</div><div class="info">Added a .gitignore file to a repository.</div></li>
+<li><div class="title">Carpenter</div><div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
 <li><div class="title">Cathedral Architect</div><div class="info">Added a submodule to a repository.</div></li>
 <li><div class="title">Cathedral Worker</div><div class="info">Cloned submodule repository and checked out commits specified by superproject.</div></li>
+<li><div class="title">Cherry Picker</div><div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-cherry-pick.html">git-cherry-pick</a> to add a sha from another branch into the current branch.</div></li>
+<li><div class="title">Chimney Sweeper</div><div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-gc.html">git-gc</a> to run a number of housekeeping tasks on the current repository.</div></li>
+<li><div class="title">Cleaning lady</div><div class="info">Remove untracked files from the working tree with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-clean.html">git-clean</a></div></li>
+<li><div class="title">Collector</div><div class="info">Fetches named heads or tags from another repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-fetch.html">git-fetch</a></div></li>
 <li><div class="title">Delivery Boy</div><div class="info">Move objects and refs by archive with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-bundle.html">git-bundle</a>.</div></li>
 <li><div class="title">Dentist</div><div class="info">Extracted patches using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a> -p.</div></li>
+<li><div class="title">Fisherman</div><div class="info">Look for specified patterns in the current repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-grep.html">git-grep</a>.</div></li>
 <li><div class="title">Garage Inventor</div><div class="info">Used a custom alias for a Git command</div></li>
+<li><div class="title">Gardner</div><div class="info">Shows the commit ancestry graph with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show-branch.html">git-show-branch</a></div></li>
+<li><div class="title">Gipsy</div><div class="info">Create, list, delete a tag signed with GPG using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-tag.html">git-tag</a></div></li>
+<li><div class="title">Goldsmith</div><div class="info">Reviewed patches before committing with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">git-diff</a> --cached.</div></li>
+<li><div class="title">Historian</div><div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
+<li><div class="title">Homeowner</div><div class="info">Set global email address using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-config.html">git-config</a>.</div></li>
+<li><div class="title">Hunter</div><div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-bisect.html">git-bisect</a> to perform a binary search to find which change introduced a bug.</div></li>
+<li><div class="title">Inventor ($1)</div><div class="info">Used a command that isn't part of the built in Git command</div></li>
+<li><div class="title">Investigator</div><div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-blame.html">git-blame</a> to annotate a file with information about how each line changed.</div></li>
+<li><div class="title">Let there be light</div><div class="info">Commit without a parent.</div></li>
+<li><div class="title">Librarian</div><div class="info">Looked for change that introduce or remove a string with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a> -S</div></li>
+<li><div class="title">Locksmith</div><div class="info">Add Signed-off-by line at the end of the commit log message using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> -s.</div></li>
+<li><div class="title">Merchant</div><div class="info">Added an external repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">git-remote</a> add.</div></li>
+<li><div class="title">Messenger</div><div class="info">Applied a patch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-am.html">git-am</a>.</div></li>
+<li><div class="title">Miller</div><div class="info">Add only part of a file to the stage X times with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a> -p.</div></li>
 <li><div class="title">News Reader</div><div class="info">Show logs with difference each commit introduces with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-whatchanged.html">git-whatchanged</a></div></li>
 <li><div class="title">Pedantic</div><div class="info">Use the flow extension to encourage an orderly and standardized branching model</div></li>
+<li><div class="title">Pilgrim</div><div class="info">Performed a rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> --onto.</div></li>
+<li><div class="title">Plumber</div><div class="info">Use the internal plumbing commands of git.</div></li>
 <li><div class="title">Postman</div><div class="info">Send a collection of patches from stdin to an IMAP folder with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-imap-send.html">git-imap-send</a></div></li>
+<li><div class="title">Presenter</div><div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
+<li><div class="title">Product Manager</div><div class="info">Stash the changes in a dirty working directory away with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-stash.html">git-stash</a>.</div></li>
+<li><div class="title">Seamstress</div><div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
+<li><div class="title">Socialite</div><div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Stamp Collector</div><div class="info">Investigate old branches by using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-reflog.html">git-reflog</a> --date=relative</div></li>
+<li><div class="title">Stone Mason</div><div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
+<li><div class="title">Thug</div><div class="info">Forced pushed a branch with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a> -f</div></li>
 <li><div class="title">Traveler</div><div class="info">Streamed changes between another rcs with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-svn.html">git-svn</a> or <a href="http://www.kernel.org/pub/software/scm/git/docs/git-p4.html">git-p4</a>.</div></li>
 <li><div class="title">Tree Trimmer</div><div class="info">Rewrite branches with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-filter-branch.html">git-filter-branch</a></div></li>
+<li><div class="title">Weaver</div><div class="info">Investigate old branches by using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-reflog.html">git-reflog</a></div></li>
 <li><div class="title">Web Designer</div><div class="info">Instantly browse your working repository in gitweb with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-instaweb.html">git-instaweb</a></div></li>
 </ul></div>
 </body></html>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked        2/      51 <a href="http://github.com/icefox/git-achievements">Git Achievements</a> for 3 points<br>
+Unlocked        2/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 3 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
 <li><div class="title">Student</div>  <div class="info">Accessed the documentation for a command with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-.html">git-</a>[command] --help</div></li>

--- a/index.html
+++ b/index.html
@@ -10,28 +10,45 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked        6/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 17 points<br>
+Unlocked       10/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 34 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
+<li><div class="title">Apprentice Banker (Level 1)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
+<li><div class="title">Apprentice Banker (Level 2)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
+<li><div class="title">Apprentice Historian (Level 1)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
+<li><div class="title">Apprentice Historian (Level 2)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
+<li><div class="title">Apprentice Historian (Level 3)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Apprentice Investigator (Level 1)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-blame.html">git-blame</a> to annotate a file with information about how each line changed.</div></li>
+<li><div class="title">Apprentice News Reader (Level 1)</div>  <div class="info">Show logs with difference each commit introduces with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-whatchanged.html">git-whatchanged</a></div></li>
 <li><div class="title">Apprentice Socialite (Level 1)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Apprentice Socialite (Level 2)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Apprentice Stone Mason (Level 1)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
+<li><div class="title">Garage Inventor</div>  <div class="info">Used a custom alias for a Git command</div></li>
 <li><div class="title">Master Carpenter (Level        4)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
 <li><div class="title">Student</div>  <div class="info">Accessed the documentation for a command with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-.html">git-</a>[command] --help</div></li>
 </ul>
 Git commands sorted by usage:
 <pre style="text-align: left">
   14 achievements
-   4 status
+  12 log
+   7 checkout
+   6 status
+   4 reset
    4 push
+   3 rebase
+   3 merge
+   2 whatchanged
    2 init
    2 blame
    2 add
+   1 stash
    1 remote
+   1 pull
+   1 help
    1 diff
    1 config
    1 commit
+   1 !
 </pre>
 <script type="text/javascript">
 function showLocked() {
@@ -45,7 +62,6 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <ul>
 <li><div class="title">Archivist</div><div class="info">Prepare each commit with its patch in one file per commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-format-patch.html">git-format-patch</a></div></li>
 <li><div class="title">Author</div><div class="info">Made 2^Level commits using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a>.</div></li>
-<li><div class="title">Banker</div><div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
 <li><div class="title">Baptised</div><div class="info">Set global user name using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-config.html">git-config</a>.</div></li>
 <li><div class="title">Beach Lion</div><div class="info">Restricted login shell for GIT-only SSH access with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-shell.html">git-shell</a></div></li>
 <li><div class="title">Blacksmith</div><div class="info">Created a branch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">git-checkout</a> -b.</div></li>
@@ -60,11 +76,9 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Delivery Boy</div><div class="info">Move objects and refs by archive with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-bundle.html">git-bundle</a>.</div></li>
 <li><div class="title">Dentist</div><div class="info">Extracted patches using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a> -p.</div></li>
 <li><div class="title">Fisherman</div><div class="info">Look for specified patterns in the current repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-grep.html">git-grep</a>.</div></li>
-<li><div class="title">Garage Inventor</div><div class="info">Used a custom alias for a Git command</div></li>
 <li><div class="title">Gardner</div><div class="info">Shows the commit ancestry graph with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show-branch.html">git-show-branch</a></div></li>
 <li><div class="title">Gipsy</div><div class="info">Create, list, delete a tag signed with GPG using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-tag.html">git-tag</a></div></li>
 <li><div class="title">Goldsmith</div><div class="info">Reviewed patches before committing with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">git-diff</a> --cached.</div></li>
-<li><div class="title">Historian</div><div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Homeowner</div><div class="info">Set global email address using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-config.html">git-config</a>.</div></li>
 <li><div class="title">Hunter</div><div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-bisect.html">git-bisect</a> to perform a binary search to find which change introduced a bug.</div></li>
 <li><div class="title">Inventor ($1)</div><div class="info">Used a command that isn't part of the built in Git command</div></li>
@@ -74,7 +88,6 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Merchant</div><div class="info">Added an external repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">git-remote</a> add.</div></li>
 <li><div class="title">Messenger</div><div class="info">Applied a patch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-am.html">git-am</a>.</div></li>
 <li><div class="title">Miller</div><div class="info">Add only part of a file to the stage X times with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a> -p.</div></li>
-<li><div class="title">News Reader</div><div class="info">Show logs with difference each commit introduces with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-whatchanged.html">git-whatchanged</a></div></li>
 <li><div class="title">Pedantic</div><div class="info">Use the flow extension to encourage an orderly and standardized branching model</div></li>
 <li><div class="title">Pilgrim</div><div class="info">Performed a rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> --onto.</div></li>
 <li><div class="title">Plumber</div><div class="info">Use the internal plumbing commands of git.</div></li>

--- a/index.html
+++ b/index.html
@@ -10,16 +10,18 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked       10/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 39 points<br>
+Unlocked       12/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 43 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
 <li><div class="title">Apprentice Banker (Level 1)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
 <li><div class="title">Apprentice Banker (Level 2)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
+<li><div class="title">Apprentice Blacksmith (Level 1)</div>  <div class="info">Created a branch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">git-checkout</a> -b.</div></li>
 <li><div class="title">Apprentice Historian (Level 1)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Apprentice Historian (Level 2)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Apprentice Historian (Level 3)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Apprentice Investigator (Level 1)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-blame.html">git-blame</a> to annotate a file with information about how each line changed.</div></li>
 <li><div class="title">Apprentice News Reader (Level 1)</div>  <div class="info">Show logs with difference each commit introduces with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-whatchanged.html">git-whatchanged</a></div></li>
+<li><div class="title">Apprentice Product Manager (Level 1)</div>  <div class="info">Stash the changes in a dirty working directory away with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-stash.html">git-stash</a>.</div></li>
 <li><div class="title">Apprentice Socialite (Level 1)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Apprentice Socialite (Level 2)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Apprentice Stone Mason (Level 1)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
@@ -30,10 +32,10 @@ Unlocked       10/      51 <a href="http://github.com/hanxue/git-achievements">G
 </ul>
 Git commands sorted by usage:
 <pre style="text-align: left">
-  18 achievements
-  15 log
-   9 checkout
-   7 status
+  20 achievements
+  16 log
+  10 checkout
+   9 status
    4 reset
    4 push
    3 rebase
@@ -41,16 +43,17 @@ Git commands sorted by usage:
    3 diff
    3 !
    2 whatchanged
+   2 stash
    2 rm
+   2 mv
    2 init
    2 help
    2 config
+   2 commit
    2 blame
    2 add
-   1 stash
    1 remote
    1 pull
-   1 commit
    1 clone
    1 branch
 </pre>
@@ -68,7 +71,6 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Author</div><div class="info">Made 2^Level commits using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a>.</div></li>
 <li><div class="title">Baptised</div><div class="info">Set global user name using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-config.html">git-config</a>.</div></li>
 <li><div class="title">Beach Lion</div><div class="info">Restricted login shell for GIT-only SSH access with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-shell.html">git-shell</a></div></li>
-<li><div class="title">Blacksmith</div><div class="info">Created a branch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">git-checkout</a> -b.</div></li>
 <li><div class="title">Butcher</div><div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
 <li><div class="title">Caretaker</div><div class="info">Added a .gitignore file to a repository.</div></li>
 <li><div class="title">Cathedral Architect</div><div class="info">Added a submodule to a repository.</div></li>
@@ -97,7 +99,6 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Plumber</div><div class="info">Use the internal plumbing commands of git.</div></li>
 <li><div class="title">Postman</div><div class="info">Send a collection of patches from stdin to an IMAP folder with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-imap-send.html">git-imap-send</a></div></li>
 <li><div class="title">Presenter</div><div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Product Manager</div><div class="info">Stash the changes in a dirty working directory away with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-stash.html">git-stash</a>.</div></li>
 <li><div class="title">Seamstress</div><div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
 <li><div class="title">Stamp Collector</div><div class="info">Investigate old branches by using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-reflog.html">git-reflog</a> --date=relative</div></li>
 <li><div class="title">Thug</div><div class="info">Forced pushed a branch with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a> -f</div></li>

--- a/index.html
+++ b/index.html
@@ -10,19 +10,28 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked        2/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 3 points<br>
+Unlocked        6/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 17 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
+<li><div class="title">Apprentice Investigator (Level 1)</div>  <div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-blame.html">git-blame</a> to annotate a file with information about how each line changed.</div></li>
+<li><div class="title">Apprentice Socialite (Level 1)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
+<li><div class="title">Apprentice Socialite (Level 2)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
+<li><div class="title">Apprentice Stone Mason (Level 1)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
+<li><div class="title">Master Carpenter (Level        4)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
 <li><div class="title">Student</div>  <div class="info">Accessed the documentation for a command with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-.html">git-</a>[command] --help</div></li>
 </ul>
 Git commands sorted by usage:
 <pre style="text-align: left">
-  11 achievements
-   3 status
+  14 achievements
+   4 status
+   4 push
    2 init
+   2 blame
+   2 add
    1 remote
+   1 diff
    1 config
-   1 add
+   1 commit
 </pre>
 <script type="text/javascript">
 function showLocked() {
@@ -42,7 +51,6 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Blacksmith</div><div class="info">Created a branch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">git-checkout</a> -b.</div></li>
 <li><div class="title">Butcher</div><div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
 <li><div class="title">Caretaker</div><div class="info">Added a .gitignore file to a repository.</div></li>
-<li><div class="title">Carpenter</div><div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
 <li><div class="title">Cathedral Architect</div><div class="info">Added a submodule to a repository.</div></li>
 <li><div class="title">Cathedral Worker</div><div class="info">Cloned submodule repository and checked out commits specified by superproject.</div></li>
 <li><div class="title">Cherry Picker</div><div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-cherry-pick.html">git-cherry-pick</a> to add a sha from another branch into the current branch.</div></li>
@@ -60,7 +68,6 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Homeowner</div><div class="info">Set global email address using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-config.html">git-config</a>.</div></li>
 <li><div class="title">Hunter</div><div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-bisect.html">git-bisect</a> to perform a binary search to find which change introduced a bug.</div></li>
 <li><div class="title">Inventor ($1)</div><div class="info">Used a command that isn't part of the built in Git command</div></li>
-<li><div class="title">Investigator</div><div class="info">Used <a href="http://www.kernel.org/pub/software/scm/git/docs/git-blame.html">git-blame</a> to annotate a file with information about how each line changed.</div></li>
 <li><div class="title">Let there be light</div><div class="info">Commit without a parent.</div></li>
 <li><div class="title">Librarian</div><div class="info">Looked for change that introduce or remove a string with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a> -S</div></li>
 <li><div class="title">Locksmith</div><div class="info">Add Signed-off-by line at the end of the commit log message using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> -s.</div></li>
@@ -75,9 +82,7 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Presenter</div><div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
 <li><div class="title">Product Manager</div><div class="info">Stash the changes in a dirty working directory away with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-stash.html">git-stash</a>.</div></li>
 <li><div class="title">Seamstress</div><div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
-<li><div class="title">Socialite</div><div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Stamp Collector</div><div class="info">Investigate old branches by using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-reflog.html">git-reflog</a> --date=relative</div></li>
-<li><div class="title">Stone Mason</div><div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
 <li><div class="title">Thug</div><div class="info">Forced pushed a branch with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a> -f</div></li>
 <li><div class="title">Traveler</div><div class="info">Streamed changes between another rcs with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-svn.html">git-svn</a> or <a href="http://www.kernel.org/pub/software/scm/git/docs/git-p4.html">git-p4</a>.</div></li>
 <li><div class="title">Tree Trimmer</div><div class="info">Rewrite branches with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-filter-branch.html">git-filter-branch</a></div></li>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked       15/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 51 points<br>
+Unlocked       16/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 53 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
 <li><div class="title">Apprentice Banker (Level 1)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
@@ -23,6 +23,7 @@ Unlocked       15/      51 <a href="http://github.com/hanxue/git-achievements">G
 <li><div class="title">Apprentice Merchant (Level 1)</div>  <div class="info">Added an external repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">git-remote</a> add.</div></li>
 <li><div class="title">Apprentice News Reader (Level 1)</div>  <div class="info">Show logs with difference each commit introduces with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-whatchanged.html">git-whatchanged</a></div></li>
 <li><div class="title">Apprentice Product Manager (Level 1)</div>  <div class="info">Stash the changes in a dirty working directory away with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-stash.html">git-stash</a>.</div></li>
+<li><div class="title">Apprentice Seamstress (Level 1)</div>  <div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
 <li><div class="title">Apprentice Socialite (Level 1)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Apprentice Socialite (Level 2)</div>  <div class="info">pushed a branch to a remote repository using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a></div></li>
 <li><div class="title">Apprentice Stone Mason (Level 1)</div>  <div class="info">Added files to the index area for inclusion in the next commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">git-add</a></div></li>
@@ -36,16 +37,18 @@ Unlocked       15/      51 <a href="http://github.com/hanxue/git-achievements">G
 </ul>
 Git commands sorted by usage:
 <pre style="text-align: left">
-  22 log
+  23 log
   22 achievements
+  10 status
   10 checkout
-   9 status
-   6 diff
+   7 diff
+   7 config
    5 remote
-   5 config
    4 reset
    4 push
    4 instaweb
+   4 commit
+   4 add
    4 !
    3 stash
    3 rebase
@@ -57,9 +60,8 @@ Git commands sorted by usage:
    2 reflog
    2 mv
    2 init
-   2 commit
    2 blame
-   2 add
+   2 -C
    1 tag
    1 show-branch
    1 pull
@@ -107,7 +109,6 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Plumber</div><div class="info">Use the internal plumbing commands of git.</div></li>
 <li><div class="title">Postman</div><div class="info">Send a collection of patches from stdin to an IMAP folder with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-imap-send.html">git-imap-send</a></div></li>
 <li><div class="title">Presenter</div><div class="info">Shows one or more objects (blobs, trees, tags and commits) with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-show.html">git-show</a></div></li>
-<li><div class="title">Seamstress</div><div class="info">amended a commit with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a> --amend.</div></li>
 <li><div class="title">Stamp Collector</div><div class="info">Investigate old branches by using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-reflog.html">git-reflog</a> --date=relative</div></li>
 <li><div class="title">Thug</div><div class="info">Forced pushed a branch with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a> -f</div></li>
 <li><div class="title">Traveler</div><div class="info">Streamed changes between another rcs with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-svn.html">git-svn</a> or <a href="http://www.kernel.org/pub/software/scm/git/docs/git-p4.html">git-p4</a>.</div></li>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked       16/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 53 points<br>
+Unlocked       16/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 59 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
 <li><div class="title">Apprentice Banker (Level 1)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
@@ -31,29 +31,31 @@ Unlocked       16/      51 <a href="http://github.com/hanxue/git-achievements">G
 <li><div class="title">Apprentice Web Designer (Level 2)</div>  <div class="info">Instantly browse your working repository in gitweb with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-instaweb.html">git-instaweb</a></div></li>
 <li><div class="title">Garage Inventor</div>  <div class="info">Used a custom alias for a Git command</div></li>
 <li><div class="title">Historian (Level 4)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
+<li><div class="title">Historian (Level 5)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Master Carpenter (Level        4)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
 <li><div class="title">Student</div>  <div class="info">Accessed the documentation for a command with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-.html">git-</a>[command] --help</div></li>
 <li><div class="title">Weaver</div>  <div class="info">Investigate old branches by using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-reflog.html">git-reflog</a></div></li>
 </ul>
 Git commands sorted by usage:
 <pre style="text-align: left">
-  23 log
+  28 log
   22 achievements
+  12 checkout
   10 status
-  10 checkout
+   9 remote
+   8 config
    7 diff
-   7 config
-   5 remote
+   5 push
+   5 !
    4 reset
-   4 push
+   4 rebase
+   4 merge
    4 instaweb
+   4 help
    4 commit
    4 add
-   4 !
    3 stash
-   3 rebase
-   3 merge
-   3 help
+   3 branch
    2 whatchanged
    2 submodule
    2 rm
@@ -66,7 +68,6 @@ Git commands sorted by usage:
    1 show-branch
    1 pull
    1 clone
-   1 branch
 </pre>
 <script type="text/javascript">
 function showLocked() {

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked       12/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 43 points<br>
+Unlocked       13/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 44 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
 <li><div class="title">Apprentice Banker (Level 1)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
@@ -29,6 +29,7 @@ Unlocked       12/      51 <a href="http://github.com/hanxue/git-achievements">G
 <li><div class="title">Historian (Level 4)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Master Carpenter (Level        4)</div>  <div class="info">Custom <a href="http://www.kernel.org/pub/software/scm/git/docs/githooks.html">git-hooks</a> are installed which help catch issues before they are shared.</div></li>
 <li><div class="title">Student</div>  <div class="info">Accessed the documentation for a command with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-.html">git-</a>[command] --help</div></li>
+<li><div class="title">Weaver</div>  <div class="info">Investigate old branches by using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-reflog.html">git-reflog</a></div></li>
 </ul>
 Git commands sorted by usage:
 <pre style="text-align: left">
@@ -53,6 +54,7 @@ Git commands sorted by usage:
    2 blame
    2 add
    1 remote
+   1 reflog
    1 pull
    1 clone
    1 branch
@@ -104,7 +106,6 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Thug</div><div class="info">Forced pushed a branch with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">git-push</a> -f</div></li>
 <li><div class="title">Traveler</div><div class="info">Streamed changes between another rcs with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-svn.html">git-svn</a> or <a href="http://www.kernel.org/pub/software/scm/git/docs/git-p4.html">git-p4</a>.</div></li>
 <li><div class="title">Tree Trimmer</div><div class="info">Rewrite branches with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-filter-branch.html">git-filter-branch</a></div></li>
-<li><div class="title">Weaver</div><div class="info">Investigate old branches by using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-reflog.html">git-reflog</a></div></li>
 <li><div class="title">Web Designer</div><div class="info">Instantly browse your working repository in gitweb with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-instaweb.html">git-instaweb</a></div></li>
 </ul></div>
 </body></html>

--- a/index.html
+++ b/index.html
@@ -10,12 +10,13 @@
 <body>
 
 <h2>Lee Hanxue's Git Achievements <img src='http://www.gravatar.com/avatar/a79fbdafc84d38fa355cb1a3f342de14'/></h2>
-Unlocked       16/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 59 points<br>
+Unlocked       17/      51 <a href="http://github.com/hanxue/git-achievements">Git Achievements</a> for 61 points<br>
 <ul>
 <li><div class="title">Apprentice Architect (Level 1)</div>  <div class="info">Created a new repository with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">git-init</a>.</div></li>
 <li><div class="title">Apprentice Banker (Level 1)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
 <li><div class="title">Apprentice Banker (Level 2)</div>  <div class="info">Join two or more development histories together with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">git-merge</a>.</div></li>
 <li><div class="title">Apprentice Blacksmith (Level 1)</div>  <div class="info">Created a branch using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">git-checkout</a> -b.</div></li>
+<li><div class="title">Apprentice Butcher (Level 1)</div>  <div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
 <li><div class="title">Apprentice Historian (Level 1)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Apprentice Historian (Level 2)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
 <li><div class="title">Apprentice Historian (Level 3)</div>  <div class="info">Investigate the commit log using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">git-log</a>.</div></li>
@@ -38,17 +39,17 @@ Unlocked       16/      51 <a href="http://github.com/hanxue/git-achievements">G
 </ul>
 Git commands sorted by usage:
 <pre style="text-align: left">
-  28 log
+  29 log
   22 achievements
   12 checkout
   10 status
    9 remote
    8 config
    7 diff
+   5 rebase
    5 push
    5 !
    4 reset
-   4 rebase
    4 merge
    4 instaweb
    4 help
@@ -83,7 +84,6 @@ There are       51 Achievements. Some achievements can be leveled up depending o
 <li><div class="title">Author</div><div class="info">Made 2^Level commits using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">git-commit</a>.</div></li>
 <li><div class="title">Baptised</div><div class="info">Set global user name using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-config.html">git-config</a>.</div></li>
 <li><div class="title">Beach Lion</div><div class="info">Restricted login shell for GIT-only SSH access with <a href="http://www.kernel.org/pub/software/scm/git/docs/git-shell.html">git-shell</a></div></li>
-<li><div class="title">Butcher</div><div class="info">Performed an interactive rebase using <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html">git-rebase</a> -i.</div></li>
 <li><div class="title">Caretaker</div><div class="info">Added a .gitignore file to a repository.</div></li>
 <li><div class="title">Cathedral Architect</div><div class="info">Added a submodule to a repository.</div></li>
 <li><div class="title">Cathedral Worker</div><div class="info">Cloned submodule repository and checked out commits specified by superproject.</div></li>

--- a/index.rss
+++ b/index.rss
@@ -2,6 +2,7 @@
 <title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
+<item><title>Apprentice Merchant (Level 1)</title><description>Added an external repository with git remote add.</description></item>
 <item><title>Weaver</title><description>Investigate old branches by using git reflog</description></item>
 <item><title>Apprentice Blacksmith (Level 1)</title><description>Created a branch using git checkout -b.</description></item>
 <item><title>Apprentice Product Manager (Level 1)</title><description>Stash the changes in a dirty working directory away with git stash.</description></item>

--- a/index.rss
+++ b/index.rss
@@ -2,6 +2,7 @@
 <title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
+<item><title>Apprentice Seamstress (Level 1)</title><description>amended a commit with git commit --amend.</description></item>
 <item><title>Apprentice Web Designer (Level 2)</title><description>Instantly browse your working repository in gitweb with git instaweb</description></item>
 <item><title>Apprentice Web Designer (Level 1)</title><description>Instantly browse your working repository in gitweb with git instaweb</description></item>
 <item><title>Apprentice Merchant (Level 1)</title><description>Added an external repository with git remote add.</description></item>
@@ -21,5 +22,4 @@
 <item><title>Apprentice Socialite (Level 1)</title><description>pushed a branch to a remote repository using git push</description></item>
 <item><title>Master Carpenter (Level        4)</title><description>Custom git hooks are installed which help catch issues before they are shared.</description></item>
 <item><title>Apprentice Stone Mason (Level 1)</title><description>Added files to the index area for inclusion in the next commit with git add</description></item>
-<item><title>Apprentice Architect (Level 1)</title><description>Created a new repository with git init.</description></item>
 </channel></rss>

--- a/index.rss
+++ b/index.rss
@@ -2,6 +2,7 @@
 <title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
+<item><title>Apprentice Web Designer (Level 2)</title><description>Instantly browse your working repository in gitweb with git instaweb</description></item>
 <item><title>Apprentice Web Designer (Level 1)</title><description>Instantly browse your working repository in gitweb with git instaweb</description></item>
 <item><title>Apprentice Merchant (Level 1)</title><description>Added an external repository with git remote add.</description></item>
 <item><title>Weaver</title><description>Investigate old branches by using git reflog</description></item>
@@ -21,5 +22,4 @@
 <item><title>Master Carpenter (Level        4)</title><description>Custom git hooks are installed which help catch issues before they are shared.</description></item>
 <item><title>Apprentice Stone Mason (Level 1)</title><description>Added files to the index area for inclusion in the next commit with git add</description></item>
 <item><title>Apprentice Architect (Level 1)</title><description>Created a new repository with git init.</description></item>
-<item><title>Student</title><description>Accessed the documentation for a command with git [command] --help</description></item>
 </channel></rss>

--- a/index.rss
+++ b/index.rss
@@ -2,6 +2,7 @@
 <title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
+<item><title>Weaver</title><description>Investigate old branches by using git reflog</description></item>
 <item><title>Apprentice Blacksmith (Level 1)</title><description>Created a branch using git checkout -b.</description></item>
 <item><title>Apprentice Product Manager (Level 1)</title><description>Stash the changes in a dirty working directory away with git stash.</description></item>
 <item><title>Historian (Level 4)</title><description>Investigate the commit log using git log.</description></item>

--- a/index.rss
+++ b/index.rss
@@ -2,6 +2,11 @@
 <title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
+<item><title>Apprentice Socialite (Level 2)</title><description>pushed a branch to a remote repository using git push</description></item>
+<item><title>Apprentice Investigator (Level 1)</title><description>Used git blame to annotate a file with information about how each line changed.</description></item>
+<item><title>Apprentice Socialite (Level 1)</title><description>pushed a branch to a remote repository using git push</description></item>
+<item><title>Master Carpenter (Level        4)</title><description>Custom git hooks are installed which help catch issues before they are shared.</description></item>
+<item><title>Apprentice Stone Mason (Level 1)</title><description>Added files to the index area for inclusion in the next commit with git add</description></item>
 <item><title>Apprentice Architect (Level 1)</title><description>Created a new repository with git init.</description></item>
 <item><title>Student</title><description>Accessed the documentation for a command with git [command] --help</description></item>
 </channel></rss>

--- a/index.rss
+++ b/index.rss
@@ -2,6 +2,13 @@
 <title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
+<item><title>Apprentice News Reader (Level 1)</title><description>Show logs with difference each commit introduces with git whatchanged</description></item>
+<item><title>Apprentice Historian (Level 3)</title><description>Investigate the commit log using git log.</description></item>
+<item><title>Apprentice Historian (Level 2)</title><description>Investigate the commit log using git log.</description></item>
+<item><title>Apprentice Historian (Level 1)</title><description>Investigate the commit log using git log.</description></item>
+<item><title>Apprentice Banker (Level 2)</title><description>Join two or more development histories together with git merge.</description></item>
+<item><title>Garage Inventor</title><description>Used a custom alias for a Git command</description></item>
+<item><title>Apprentice Banker (Level 1)</title><description>Join two or more development histories together with git merge.</description></item>
 <item><title>Apprentice Socialite (Level 2)</title><description>pushed a branch to a remote repository using git push</description></item>
 <item><title>Apprentice Investigator (Level 1)</title><description>Used git blame to annotate a file with information about how each line changed.</description></item>
 <item><title>Apprentice Socialite (Level 1)</title><description>pushed a branch to a remote repository using git push</description></item>

--- a/index.rss
+++ b/index.rss
@@ -2,6 +2,7 @@
 <title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
+<item><title>Apprentice Butcher (Level 1)</title><description>Performed an interactive rebase using git rebase -i.</description></item>
 <item><title>Historian (Level 5)</title><description>Investigate the commit log using git log.</description></item>
 <item><title>Apprentice Seamstress (Level 1)</title><description>amended a commit with git commit --amend.</description></item>
 <item><title>Apprentice Web Designer (Level 2)</title><description>Instantly browse your working repository in gitweb with git instaweb</description></item>
@@ -21,5 +22,4 @@
 <item><title>Apprentice Socialite (Level 2)</title><description>pushed a branch to a remote repository using git push</description></item>
 <item><title>Apprentice Investigator (Level 1)</title><description>Used git blame to annotate a file with information about how each line changed.</description></item>
 <item><title>Apprentice Socialite (Level 1)</title><description>pushed a branch to a remote repository using git push</description></item>
-<item><title>Master Carpenter (Level        4)</title><description>Custom git hooks are installed which help catch issues before they are shared.</description></item>
 </channel></rss>

--- a/index.rss
+++ b/index.rss
@@ -2,6 +2,7 @@
 <title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
+<item><title>Apprentice Web Designer (Level 1)</title><description>Instantly browse your working repository in gitweb with git instaweb</description></item>
 <item><title>Apprentice Merchant (Level 1)</title><description>Added an external repository with git remote add.</description></item>
 <item><title>Weaver</title><description>Investigate old branches by using git reflog</description></item>
 <item><title>Apprentice Blacksmith (Level 1)</title><description>Created a branch using git checkout -b.</description></item>

--- a/index.rss
+++ b/index.rss
@@ -2,6 +2,7 @@
 <title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
+<item><title>Historian (Level 5)</title><description>Investigate the commit log using git log.</description></item>
 <item><title>Apprentice Seamstress (Level 1)</title><description>amended a commit with git commit --amend.</description></item>
 <item><title>Apprentice Web Designer (Level 2)</title><description>Instantly browse your working repository in gitweb with git instaweb</description></item>
 <item><title>Apprentice Web Designer (Level 1)</title><description>Instantly browse your working repository in gitweb with git instaweb</description></item>
@@ -21,5 +22,4 @@
 <item><title>Apprentice Investigator (Level 1)</title><description>Used git blame to annotate a file with information about how each line changed.</description></item>
 <item><title>Apprentice Socialite (Level 1)</title><description>pushed a branch to a remote repository using git push</description></item>
 <item><title>Master Carpenter (Level        4)</title><description>Custom git hooks are installed which help catch issues before they are shared.</description></item>
-<item><title>Apprentice Stone Mason (Level 1)</title><description>Added files to the index area for inclusion in the next commit with git add</description></item>
 </channel></rss>

--- a/index.rss
+++ b/index.rss
@@ -2,6 +2,8 @@
 <title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
+<item><title>Apprentice Blacksmith (Level 1)</title><description>Created a branch using git checkout -b.</description></item>
+<item><title>Apprentice Product Manager (Level 1)</title><description>Stash the changes in a dirty working directory away with git stash.</description></item>
 <item><title>Historian (Level 4)</title><description>Investigate the commit log using git log.</description></item>
 <item><title>Apprentice News Reader (Level 1)</title><description>Show logs with difference each commit introduces with git whatchanged</description></item>
 <item><title>Apprentice Historian (Level 3)</title><description>Investigate the commit log using git log.</description></item>

--- a/index.rss
+++ b/index.rss
@@ -1,25 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><rss version="2.0"><channel>
-<title>Benjamin C Meyer's Git Achievements</title>
+<title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
-<item><title>Master Miller (Level 7)</title><description>Add only part of a file to the stage 1704 times with git add -p.</description></item>
-<item><title>Master Presenter (Level 10)</title><description>Shows one or more objects (blobs, trees, tags and commits) with git show</description></item>
-<item><title>Master Seamstress (Level 8)</title><description>amended a commit with git commit --amend.</description></item>
-<item><title>Master Carpenter (Level       14)</title><description>Custom git hooks are installed which help catch issues before they are shared.</description></item>
-<item><title>Hunter (Level 4)</title><description>Used git bisect to perform a binary search to find which change introduced a bug.</description></item>
-<item><title>Architect (Level 5)</title><description>Created a new repository with git init.</description></item>
-<item><title>Apprentice Plumber (Level 2)</title><description>Use the internal plumbing commands of git.</description></item>
-<item><title>Apprentice Plumber (Level 1)</title><description>Use the internal plumbing commands of git.</description></item>
-<item><title>Apprentice Gardner (Level 1)</title><description>Shows the commit ancestry graph with git show-branch</description></item>
-<item><title>Blacksmith (Level 5)</title><description>Created a branch using git checkout -b.</description></item>
-<item><title>Miller (Level 6)</title><description>Add only part of a file to the stage 1262 times with git add -p.</description></item>
-<item><title>Merchant (Level 5)</title><description>Added an external repository with git remote add.</description></item>
-<item><title>Architect (Level 4)</title><description>Created a new repository with git init.</description></item>
-<item><title>Product Manager (Level 4)</title><description>Stash the changes in a dirty working directory away with git stash.</description></item>
-<item><title>Archivist (Level 4)</title><description>Prepare each commit with its patch in one file per commit with git format-patch</description></item>
-<item><title>Miller (Level 5)</title><description>Add only part of a file to the stage 1057 times with git add -p.</description></item>
-<item><title>Master Author (Level 9)</title><description>Made 2^Level commits using git commit.</description></item>
-<item><title>Master Socialite (Level 8)</title><description>pushed a branch to a remote repository using git push</description></item>
-<item><title>Miller (Level 4)</title><description>Add only part of a file to the stage 1028 times with git add -p.</description></item>
-<item><title>Master Stone Mason (Level 10)</title><description>Added files to the index area for inclusion in the next commit with git add</description></item>
+<item><title>Apprentice Architect (Level 1)</title><description>Created a new repository with git init.</description></item>
+<item><title>Student</title><description>Accessed the documentation for a command with git [command] --help</description></item>
 </channel></rss>

--- a/index.rss
+++ b/index.rss
@@ -2,6 +2,7 @@
 <title>Lee Hanxue's Git Achievements</title>
 <description></description>
 <link></link>
+<item><title>Historian (Level 4)</title><description>Investigate the commit log using git log.</description></item>
 <item><title>Apprentice News Reader (Level 1)</title><description>Show logs with difference each commit introduces with git whatchanged</description></item>
 <item><title>Apprentice Historian (Level 3)</title><description>Investigate the commit log using git log.</description></item>
 <item><title>Apprentice Historian (Level 2)</title><description>Investigate the commit log using git log.</description></item>


### PR DESCRIPTION
`readlink` works differently on MacOS (and other BSD systems) - if the argument is *not* a symlink, it will return an error instead of the actual directory. 

This change will assume GNU coreutils' `readlink` is installed and available in the `$PATH` as `greadlink`
