### PR TITLE
Fix changing directory in MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,18 @@ You can get your first achievement by running
 ```
 git achievements --help
 ```
+
+### macOS
+
+You need to install GNU Coreutils and make the GNU `readlink` command available as `greadlink`. An easy way to do that is to use Homebrew to install coreutils. 
+
+```
+brew update && brew install coreutils
+```
+
+Run the followng command or add it to your `~/.bash_profile~
+
+```
+export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+```
+

--- a/git-achievements
+++ b/git-achievements
@@ -371,8 +371,14 @@ function publish_achievements
 {
     git_achievements="$(which git-achievements)"
     git_achievements_dir="$(dirname "${git_achievements}")"
+    value=""
+    if ! type "greadlink" > /dev/null; then
+        value="$(dirname $(readlink ${git_achievements}))"
+    else
+        value="$(dirname $(greadlink ${git_achievements}))"
+    fi
     if [ -L "${git_achievements}" ]; then
-      case "$(dirname $(readlink ${git_achievements}))" in
+      case ${value} in
         /*)
           git_achievements_dir="$(dirname $(readlink ${git_achievements}))"
           ;;


### PR DESCRIPTION
`readlink` works differently on MacOS (and other BSD systems) - if the argument is *not* a symlink, it will return an error instead of the actual directory. 

This change will assume GNU coreutils' `readlink` is installed and available in the `$PATH` as `greadlink`